### PR TITLE
Fix menubar window doesn't show up when opening second instance

### DIFF
--- a/main-src/electron.js
+++ b/main-src/electron.js
@@ -582,7 +582,7 @@ if (!gotTheLock) {
     const win = mainWindow.get();
     if (win != null) {
       if (win.isMinimized()) win.restore();
-      win.focus();
+      win.show();
     }
 
     // handle protocols on Windows & Linux


### PR DESCRIPTION
Resolve https://github.com/webcatalog/webcatalog-app/issues/1430