### PR TITLE
Set window.PushManager to undefined to improve notification compatibility

### DIFF
--- a/main-src/libs/view-preload.js
+++ b/main-src/libs/view-preload.js
@@ -396,6 +396,8 @@ webFrame.executeJavaScript(`
     webcatalog.setBadgeCount(contents);
     return Promise.resolve();
   };
+
+  window.PushManager = undefined;
 })();
 `);
 // enable pinch zooming (default behavior of Chromium)


### PR DESCRIPTION
https://github.com/webcatalog/webcatalog-app/issues/1457