### PR TITLE
Fix "cannot read properties of undefined (reading 'request')"

### DIFF
--- a/main-src/libs/view-preload/dark-reader.js
+++ b/main-src/libs/view-preload/dark-reader.js
@@ -10,7 +10,7 @@ const {
   setFetchMethod: setFetchMethodDarkMode,
 } = require('darkreader');
 
-const fetch = require('../customized-fetch');
+const fetch = require('node-fetch').default;
 
 require('./webcatalog-api');
 

--- a/patches/darkreader+4.9.40.patch
+++ b/patches/darkreader+4.9.40.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/darkreader/darkreader.js b/node_modules/darkreader/darkreader.js
-index 45a9b79..b5c1fb2 100644
+index 45a9b79..2d2c3f6 100644
 --- a/node_modules/darkreader/darkreader.js
 +++ b/node_modules/darkreader/darkreader.js
-@@ -228,17 +228,15 @@
+@@ -228,17 +228,13 @@
      }
      function readResponseAsDataURL(response) {
          return __awaiter(this, void 0, void 0, function () {
@@ -10,10 +10,7 @@ index 45a9b79..b5c1fb2 100644
 +            var _dataURL, dataURL;
              return __generator(this, function (_a) {
                  switch (_a.label) {
--                    case 0: return [4, response.blob()];
-+                    // response.blob() is incompatible with Electron preload environment
-+                    // as it is not isomorphic
-+                    case 0: return [4, response.dataUrl()];
+                     case 0: return [4, response.blob()];
                      case 1:
 -                        blob = _a.sent();
 -                        return [4, (new Promise(function (resolve) {

--- a/public/open-source-notices-automated.txt
+++ b/public/open-source-notices-automated.txt
@@ -21735,7 +21735,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----
 
-The following software may be included in this product: source-map, source-map-js. A copy of the source code may be downloaded from http://github.com/mozilla/source-map.git (source-map), http://github.com/7rulnik/source-map.git (source-map-js). This software contains the following license and notice below:
+The following software may be included in this product: source-map, source-map-js. A copy of the source code may be downloaded from http://github.com/mozilla/source-map.git (source-map), https://github.com/7rulnik/source-map.git (source-map-js). This software contains the following license and notice below:
 
 Copyright (c) 2009-2011, Mozilla Foundation and contributors
 All rights reserved.


### PR DESCRIPTION
when using `electron-fetch` in preload script