### PR TITLE
Fix BrowserView size is miscalculated when window is focused on Windows

### DIFF
--- a/main-src/windows/main.js
+++ b/main-src/windows/main.js
@@ -392,6 +392,10 @@ const createAsync = () => new Promise((resolve) => {
     if (view && view.webContents) {
       view.webContents.focus();
     }
+
+    // fix bug: BrowserView size is miscalculated when window is blurred on Windows
+    // https://github.com/webcatalog/webcatalog-app/issues/1599
+    ipcMain.emit('request-realign-active-workspace');
   });
 
   win.once('ready-to-show', () => {

--- a/src/components/main/find-in-page.js
+++ b/src/components/main/find-in-page.js
@@ -98,13 +98,13 @@ const FindInPage = (props) => {
             }
           }}
           onKeyDown={(e) => {
-            if ((e.keyCode || e.which) === 13) { // Enter
+            if (e.key === 'Enter') { // Enter
               const val = e.target.value;
               if (val.length > 0) {
                 requestFindInPage(val, true);
               }
             }
-            if ((e.keyCode || e.which) === 27) { // Escape
+            if (e.key === 'Escape') { // Escape
               requestStopFindInPage(true);
               onCloseFindInPage();
             }


### PR DESCRIPTION
Resolve https://github.com/webcatalog/webcatalog-app/issues/1599